### PR TITLE
fix: Use named imports from fs-extra

### DIFF
--- a/.changeset/warm-buses-sneeze.md
+++ b/.changeset/warm-buses-sneeze.md
@@ -1,0 +1,5 @@
+---
+"secco": patch
+---
+
+Refactor the internal usage of `fs-extra` to use named imports, not the default import. Things should continue to work as usual.

--- a/src/utils/check-deps-changes.ts
+++ b/src/utils/check-deps-changes.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra'
+import { readFile, readFileSync } from 'fs-extra'
 import fetch from 'node-fetch'
 import { isEqual, isObject, transform, uniq } from 'lodash-es'
 import destr from 'destr'
@@ -43,7 +43,7 @@ export async function checkDepsChanges(args: CheckDependencyChangesArgs) {
   try {
     // The package might already be installed (e.g. the "latest" version)
     // nodeModulesFilePath might not exist, but this is okay since we catch the resulting error
-    nodeModulePkgJson = destr<PackageJson>(fs.readFileSync(args.nodeModulesFilePath, 'utf8'))
+    nodeModulePkgJson = destr<PackageJson>(readFileSync(args.nodeModulesFilePath, 'utf8'))
   }
   catch {
     pkgNotInstalled = true
@@ -89,7 +89,7 @@ export async function checkDepsChanges(args: CheckDependencyChangesArgs) {
     }
   }
 
-  const sourcePkgJsonString = await fs.readFile(sourcePkgJsonPath, 'utf8')
+  const sourcePkgJsonString = await readFile(sourcePkgJsonPath, 'utf8')
   const sourcePkgJson = destr<PackageJson>(sourcePkgJsonString)
 
   if (args.ignoredPackageJson.has(args.packageName)) {

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,11 +1,11 @@
 import { destr } from 'destr'
-import fs from 'fs-extra'
+import { access, readFileSync } from 'fs-extra'
 import { join } from 'pathe'
 import type { PackageJson } from '../types'
 
 export async function pathExists(p: string) {
   try {
-    await fs.access(p)
+    await access(p)
     return true
   }
   catch {
@@ -18,7 +18,7 @@ export async function pathExists(p: string) {
  * Falls back to 'latest' if no version is found.
  */
 export function getPackageVersion(packageName: string) {
-  const pkgJson = destr<PackageJson>(fs.readFileSync('./package.json', 'utf8'))
+  const pkgJson = destr<PackageJson>(readFileSync('./package.json', 'utf8'))
 
   const { dependencies = {}, devDependencies = {} } = pkgJson
   const version = dependencies[packageName] || devDependencies[packageName]

--- a/src/utils/initial-setup.ts
+++ b/src/utils/initial-setup.ts
@@ -1,5 +1,5 @@
 import process from 'node:process'
-import fs from 'fs-extra'
+import { existsSync, readFileSync } from 'fs-extra'
 import { intersection, merge } from 'lodash-es'
 import { findWorkspaces } from 'find-workspaces'
 import { join } from 'pathe'
@@ -12,7 +12,7 @@ const currentDir = process.cwd()
 
 export function checkDirHasPackageJson() {
   const packageJsonPath = `${currentDir}/package.json`
-  const hasFile = fs.existsSync(packageJsonPath)
+  const hasFile = existsSync(packageJsonPath)
 
   if (!hasFile) {
     logger.fatal(`No \`package.json\` found in ${currentDir}
@@ -33,7 +33,7 @@ export function findWorkspacesInSource(sourcePath: Source['path']) {
 
 export function hasConfigFile() {
   const configPath = join(currentDir, CONFIG_FILE_NAME)
-  return fs.existsSync(configPath)
+  return existsSync(configPath)
 }
 
 const packageNameToFilePath = new Map<string, string>()
@@ -57,7 +57,7 @@ export function getPackageNamesToFilePath() {
 export function getPackages(sourcePath: Source['path'], workspaces: ReturnType<typeof findWorkspacesInSource>['workspaces']) {
   // If workspaces is an empty Array or null, it means it's not a monorepo
   if (!workspaces) {
-    const pkgJsonPath = fs.readFileSync(join(sourcePath, 'package.json'), 'utf-8')
+    const pkgJsonPath = readFileSync(join(sourcePath, 'package.json'), 'utf-8')
     const pkgJson = destr<{ name?: string }>(pkgJsonPath)
 
     if (pkgJson?.name) {
@@ -85,7 +85,7 @@ export function getPackages(sourcePath: Source['path'], workspaces: ReturnType<t
 }
 
 export function getDestinationPackages(sourcePackages: SourcePackages) {
-  const destPkgJson = destr<{ dependencies?: Record<string, string>; devDependencies?: Record<string, string> }>(fs.readFileSync(join(currentDir, 'package.json'), 'utf-8'))
+  const destPkgJson = destr<{ dependencies?: Record<string, string>; devDependencies?: Record<string, string> }>(readFileSync(join(currentDir, 'package.json'), 'utf-8'))
 
   if (!destPkgJson)
     return []

--- a/src/verdaccio/index.ts
+++ b/src/verdaccio/index.ts
@@ -1,6 +1,6 @@
 import type { Server } from 'node:http'
 import { runServer } from 'verdaccio'
-import fs from 'fs-extra'
+import { removeSync } from 'fs-extra'
 import { intersection } from 'lodash-es'
 import { logger } from '../utils/logger'
 import type { DestinationPackages, PackageNamesToFilePath, Source } from '../types'
@@ -14,7 +14,7 @@ async function startVerdaccio() {
   logger.log('[Verdaccio] Starting server...')
 
   // Clear Verdaccio storage
-  fs.removeSync(VERDACCIO_CONFIG.storage as string)
+  removeSync(VERDACCIO_CONFIG.storage as string)
 
   return Promise.race([
     new Promise<void>((resolve) => {

--- a/src/verdaccio/publish-package.ts
+++ b/src/verdaccio/publish-package.ts
@@ -1,6 +1,6 @@
 import process from 'node:process'
 import path from 'node:path'
-import fs from 'fs-extra'
+import { existsSync, outputFileSync, readFileSync, removeSync } from 'fs-extra'
 import { execaSync } from 'execa'
 import destr from 'destr'
 import { join } from 'pathe'
@@ -28,7 +28,7 @@ type AdjustPackageJsonArgs = Omit<PublishPackageArgs, 'source'> & {
 function adjustPackageJson({ sourcePkgJsonPath, packageName, packageNamesToFilePath, packagesToPublish, ignorePackageJsonChanges, versionPostfix }: AdjustPackageJsonArgs) {
   // Check if package depends on any other package that will be published. Adjust version selector to point to "secco" version so that local registry is used for those dependencies.
 
-  const sourcePkgJsonString = fs.readFileSync(sourcePkgJsonPath, 'utf-8')
+  const sourcePkgJsonString = readFileSync(sourcePkgJsonPath, 'utf-8')
   const sourcePkgJson = destr<PackageJson>(sourcePkgJsonString)
 
   // Overwrite version with "secco" name
@@ -41,7 +41,7 @@ function adjustPackageJson({ sourcePkgJsonPath, packageName, packageNamesToFileP
       if (!srcPath)
         return
 
-      const currentVersion = destr<PackageJson>(fs.readFileSync(srcPath, 'utf-8'))?.version
+      const currentVersion = destr<PackageJson>(readFileSync(srcPath, 'utf-8'))?.version
 
       if (currentVersion)
         sourcePkgJson.dependencies[pkgToPublish] = `${currentVersion}-${CLI_NAME}-${versionPostfix}`
@@ -52,13 +52,13 @@ function adjustPackageJson({ sourcePkgJsonPath, packageName, packageNamesToFileP
 
   const revertIgnorePackageJsonChanges = ignorePackageJsonChanges(packageName, [sourcePkgJsonString, tempSourcePkgJsonString])
 
-  fs.outputFileSync(sourcePkgJsonPath, tempSourcePkgJsonString)
+  outputFileSync(sourcePkgJsonPath, tempSourcePkgJsonString)
 
   return {
     newPackageVersion: sourcePkgJson.version,
     revertAdjustPackageJson: registerCleanupTask(() => {
       // Restore original package.json file
-      fs.outputFileSync(sourcePkgJsonPath, sourcePkgJsonString)
+      outputFileSync(sourcePkgJsonPath, sourcePkgJsonString)
       revertIgnorePackageJsonChanges()
     }),
   }
@@ -80,28 +80,28 @@ function createTempNpmRc({ pathToPkg, sourcePath }: CreateTempNpmRcArgs) {
 
   // If an .npmrc file already exists in the pkg and/or source root, we should use "npm config set key=value"
 
-  if (fs.existsSync(npmRcPathInPkg)) {
+  if (existsSync(npmRcPathInPkg)) {
     execaSync('npm', ['config', 'set', NpmRcContent], { cwd: pathToPkg })
     revertPkg = true
   }
-  else { fs.outputFileSync(npmRcPathInPkg, NpmRcContent) }
+  else { outputFileSync(npmRcPathInPkg, NpmRcContent) }
 
-  if (fs.existsSync(npmRcPathInSource)) {
+  if (existsSync(npmRcPathInSource)) {
     execaSync('npm', ['config', 'set', NpmRcContent], { cwd: sourcePath })
     revertSource = true
   }
-  else { fs.outputFileSync(npmRcPathInSource, NpmRcContent) }
+  else { outputFileSync(npmRcPathInSource, NpmRcContent) }
 
   return registerCleanupTask(() => {
     if (revertPkg)
       execaSync('npm', ['config', 'delete', NpmRcConfigKey], { cwd: pathToPkg })
     else
-      fs.removeSync(npmRcPathInPkg)
+      removeSync(npmRcPathInPkg)
 
     if (revertSource)
       execaSync('npm', ['config', 'delete', NpmRcConfigKey], { cwd: sourcePath })
     else
-      fs.removeSync(npmRcPathInSource)
+      removeSync(npmRcPathInSource)
   })
 }
 

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -1,5 +1,5 @@
 import process from 'node:process'
-import fs from 'fs-extra'
+import { copy, existsSync } from 'fs-extra'
 import chokidar from 'chokidar'
 import { intersection, uniq } from 'lodash-es'
 import { join, relative } from 'pathe'
@@ -55,7 +55,7 @@ export async function watcher(source: Source, destination: Destination, packages
   function _copyPath(args: PrivateCopyPathArgs) {
     const { oldPath, newPath, resolve, reject, retry = 0 } = args
 
-    fs.copy(oldPath, newPath, (err) => {
+    copy(oldPath, newPath, (err) => {
       if (err) {
         if (retry >= MAX_COPY_RETRIES) {
           logger.error(err)
@@ -179,7 +179,7 @@ export async function watcher(source: Source, destination: Destination, packages
   const watchers = uniq(
     allPackagesToWatch
       .map(p => join(packageNamesToFilePath.get(p) as string))
-      .filter(p => fs.existsSync(p)),
+      .filter(p => existsSync(p)),
   )
 
   let allCopies: Array<Promise<void>> = []


### PR DESCRIPTION
## Description

Use named imports (`e.g. import { copy } from 'fs-extra'`) instead of default import. Makes mocking in tests easier.

## Checklist

- [x] `pnpm run test` runs as expected.
- [x] `pnpm run build` runs as expected.
- [ ] (If applicable) Documentation has been updated