### PR TITLE
fix: Use correct fs-extra subpath

### DIFF
--- a/.changeset/forty-peaches-count.md
+++ b/.changeset/forty-peaches-count.md
@@ -1,0 +1,5 @@
+---
+"secco": patch
+---
+
+Use correct `fs-extra/esm` subpath were needed to mitigate `fs.readJsonSync is not a function`

--- a/src/utils/__tests__/traverse-pkg-deps.ts
+++ b/src/utils/__tests__/traverse-pkg-deps.ts
@@ -31,8 +31,8 @@ function mockReadJsonSync(path: string) {
   }
 }
 
-vi.mock('fs-extra', async () => {
-  const actual = await vi.importActual('fs-extra') as any
+vi.mock('fs-extra/esm', async () => {
+  const actual = await vi.importActual('fs-extra/esm') as any
   return {
     ...actual,
     readJsonSync: vi.fn((path) => {

--- a/src/utils/traverse-pkg-deps.ts
+++ b/src/utils/traverse-pkg-deps.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs-extra'
+import * as fs from 'fs-extra/esm'
 import { difference, intersection } from 'lodash-es'
 import { join } from 'pathe'
 import type { DepTree, PackageJson, PackageNamesToFilePath, SourcePackages } from '../types'

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig((options) => {
     format: 'esm',
     minify: !options.watch,
     clean: true,
+    cjsInterop: true,
     outExtension() {
       return {
         js: '.mjs',


### PR DESCRIPTION
## Description

Ugh, one more fix for correct usage of `fs-extra` with `import * as fs` import. Use the `fs-extra/esm` subpath so that this works correctly.

## Checklist

- [x] `pnpm run test` runs as expected.
- [x] `pnpm run build` runs as expected.
- [ ] (If applicable) Documentation has been updated