### PR TITLE
fix: Do not double publish in pnpm workspaces with force-verdaccio

### DIFF
--- a/.changeset/nasty-turkeys-wait.md
+++ b/.changeset/nasty-turkeys-wait.md
@@ -1,0 +1,5 @@
+---
+"secco": patch
+---
+
+Do not try to publish twice if workspace/catalog protocol (pnpm) is used in source with --force-verdaccio

--- a/src/utils/check-deps-changes.ts
+++ b/src/utils/check-deps-changes.ts
@@ -134,6 +134,13 @@ export async function checkDepsChanges(args: CheckDependencyChangesArgs) {
         continue
       }
 
+      if (sourcePkgJson.dependencies[key] === 'workspace:*' || sourcePkgJson.dependencies[key]?.startsWith('catalog:')) {
+        // If the source is using pnpm workspaces with workspace or catalog protocols, the dependencies were adjusted in the "adjustPackageJson" function. The change from specific versions back to "workspace:*" or "catalog:" should be ignored here
+
+        // The check is also necessary because otherwise after a "--force-verdaccio" it tries to publish the packages again
+        continue
+      }
+
       if (
         nodeModulePkgJson.dependencies[key]
         && sourcePkgJson.dependencies[key]


### PR DESCRIPTION
## Description

Do not try to publish twice if workspace/catalog protocol (pnpm) is used in source with --force-verdaccio

## Checklist

- [ ] `pnpm run test` runs as expected.
- [ ] `pnpm run build` runs as expected.
- [ ] (If applicable) Documentation has been updated
