### PR TITLE
feat: Expand CLI commands

### DIFF
--- a/.changeset/blue-shirts-hammer.md
+++ b/.changeset/blue-shirts-hammer.md
@@ -1,0 +1,9 @@
+---
+"secco": patch
+---
+
+Various small bug fixes:
+
+- When `dist/` was in the `files` array of `package.json` it didn't correctly copy over files inside the `dist` directory
+- When `--scan-once` and `--force-verdaccio` were used together a warning was thrown about an ungraceful exit. For this codepath any cleanup tasks are run before exiting now. The warning won't show.
+- The `init` command ran the whole main function while it should only run the Enquirer prompt. This is fixed now.

--- a/.changeset/fast-rats-look.md
+++ b/.changeset/fast-rats-look.md
@@ -1,0 +1,16 @@
+---
+"secco": minor
+---
+
+The CLI got more functionality!
+
+- Add `-s` alias for `--scan-once` and `-f` for `--force-verdaccio`
+- Add `--source` and `--yes` flag for `secco init`, making it possible to run the init command in non-interactive mode
+
+    For example, this command will create a `.seccorc` file with the given source path:
+
+    ```bash
+    secco init --source=/absolute/path --yes
+    ```
+
+    If you don't provide the `--yes` flag you'll need to confirm the prompt.

--- a/README.md
+++ b/README.md
@@ -66,19 +66,21 @@ Here's an overview of all available commands and flags:
 Usage: secco <command>
 
 Commands:
-  secco init                        Initialize a new .seccorc file
+  secco                             Scan destination and copy files from source  [default]
   secco packages [packageNames...]  Specify list of packages you want to link
+  secco init                        Initialize a new .seccorc file
 
 Options:
-  --help             Show help
-  --version          Show version number
-  --scan-once        Scan source once and do not start file watching
-  --force-verdaccio  Disable file copying/watching and force usage of Verdaccio
-  --verbose          Output verbose logging
+      --help             Show help  [boolean]
+      --version          Show version number  [boolean]
+  -s, --scan-once        Scan source once and do not start file watching  [boolean] [default: false]
+  -f, --force-verdaccio  Disable file copying/watching and force usage of Verdaccio  [boolean] [default: false]
+      --verbose          Output verbose logging  [boolean] [default: false]
 
 Examples:
-  secco                     Scan destination and copy files from source
-  secco packages ars aurea  Copy specified packages from source to destination
+  secco                                     Scan destination and copy files from source
+  secco packages ars aurea                  Copy specified packages from source to destination
+  secco init --source=/absolute/path --yes  Create a .seccorc file in the current dir with the provided source path without any prompts
 ```
 
 ## Documentation

--- a/docs/src/content/docs/guide/learn-secco.mdx
+++ b/docs/src/content/docs/guide/learn-secco.mdx
@@ -64,8 +64,9 @@ Ensure that the installation was successful by running `secco --help`. You shoul
 Usage: secco <command>
 
 Commands:
-  secco init                        Initialize a new .seccorc file
+  secco                             Scan destination and copy files from source  [default]
   secco packages [packageNames...]  Specify list of packages you want to link
+  secco init                        Initialize a new .seccorc file
 ```
 
 ## How to use secco

--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -9,6 +9,17 @@ sidebar:
 
 Run this command inside your destination folder. You'll be asked questions about your source folder and at the end of the questionnaire a new `.seccorc` config file will be created.
 
+By default, the `secco init` command is an interactive prompt. However, if you want to use it in non-interactive environments you can provide both `--source` and `--yes` flags.
+
+```shell
+secco init --source=/absolute-path/to/directory --yes
+```
+
+**Optional flags:**
+
+- `--source`: Absolute path to the source directory
+- `--yes`: Skip confirmation prompts
+
 ## `secco`
 
 `secco` will scan your destination's `package.json` file and compare it with the available packages inside your source. It'll then copy over all changes into your destination's `node_modules` folder. Additionally, a watch task is started to continue copying over changes. Packages that have [`"private": true`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#private) set will be ignored.

--- a/docs/src/content/docs/reference/flags.md
+++ b/docs/src/content/docs/reference/flags.md
@@ -9,19 +9,23 @@ These are the flags that you can use with any command.
 
 ## `--help`
 
-Shows the help menu of `secco`
+Shows the help menu of `secco`.
 
 ## `--version`
 
-Displays the current version of `secco`
+Displays the current version of `secco`.
 
 ## `--scan-once`
+
+**Alias:** `-s`.
 
 By default `secco` starts a watch script to listen for changes. If you want to disable this behavior, use `--scan-once`. This way `secco` will do an initial scan, copy the changes, and then quit.
 
 This is useful for CI environments as you can e.g. set up automated test sites with latest code changes. See the [CI guide](/guide/continuous-integration/) for more information.
 
 ## `--force-verdaccio`
+
+**Alias:** `-f`.
 
 Disable the copying of files into `node_modules` and always use Verdaccio. This is helpful for ensuring in e.g. End-To-End test environments that the package installation is correct.
 

--- a/docs/src/content/docs/reference/flags.md
+++ b/docs/src/content/docs/reference/flags.md
@@ -5,19 +5,25 @@ sidebar:
   order: 99999
 ---
 
-These are the flags that you can use with any command.
+These are the flags that you can use throughout the CLI. If not noted otherwise, you can use them with every command.
 
 ## `--help`
 
-Shows the help menu of `secco`.
+Shows the help menu of `secco`. You can also show help menus of subcommands, e.g. `secco packages --help`.
 
 ## `--version`
 
 Displays the current version of `secco`.
 
+## `--verbose`
+
+Output additional debug logs and more information.
+
 ## `--scan-once`
 
-**Alias:** `-s`.
+- **Alias:** `-s`
+
+- **Commands:** `secco`, `secco packages`
 
 By default `secco` starts a watch script to listen for changes. If you want to disable this behavior, use `--scan-once`. This way `secco` will do an initial scan, copy the changes, and then quit.
 
@@ -25,10 +31,8 @@ This is useful for CI environments as you can e.g. set up automated test sites w
 
 ## `--force-verdaccio`
 
-**Alias:** `-f`.
+- **Alias:** `-f`
+
+- **Commands:** `secco`, `secco packages`
 
 Disable the copying of files into `node_modules` and always use Verdaccio. This is helpful for ensuring in e.g. End-To-End test environments that the package installation is correct.
-
-## `--verbose`
-
-Output additional debug logs and more information.

--- a/integration/__tests__/commands/help.ts
+++ b/integration/__tests__/commands/help.ts
@@ -1,0 +1,12 @@
+import { SeccoCLI } from '../../helpers/invoke-cli'
+
+describe('--help', () => {
+  it('should display usage overview', () => {
+    const [exitCode, logs] = SeccoCLI().invoke(['--help'])
+
+    logs.should.contain('Usage:')
+    logs.should.contain('Options:')
+    logs.should.contain('Examples:')
+    expect(exitCode).toBe(0)
+  })
+})

--- a/integration/__tests__/commands/init.ts
+++ b/integration/__tests__/commands/init.ts
@@ -1,5 +1,4 @@
-import { version as seccoVersion } from '../../package.json'
-import { SeccoCLI } from '../helpers/invoke-cli'
+import { SeccoCLI } from '../../helpers/invoke-cli'
 
 const initQuestion = 'What is the absolute path to your source?'
 const warning = '.seccorc file already exists in this directory'
@@ -17,26 +16,6 @@ describe('init', () => {
 
     logs.should.contain(initQuestion)
     logs.should.contain(warning)
-    expect(exitCode).toBe(0)
-  })
-})
-
-describe('--help', () => {
-  it('should display usage overview', () => {
-    const [exitCode, logs] = SeccoCLI().invoke(['--help'])
-
-    logs.should.contain('Usage:')
-    logs.should.contain('Options:')
-    logs.should.contain('Examples:')
-    expect(exitCode).toBe(0)
-  })
-})
-
-describe('--version', () => {
-  it('should display current CLI version', () => {
-    const [exitCode, logs] = SeccoCLI().invoke(['--version'])
-
-    logs.should.contain(seccoVersion)
     expect(exitCode).toBe(0)
   })
 })

--- a/integration/__tests__/commands/init.ts
+++ b/integration/__tests__/commands/init.ts
@@ -40,4 +40,10 @@ describe('init', () => {
       await cleanup()
     }
   })
+  it('should error on invalid input', () => {
+    const [exitCode, logs] = SeccoCLI().setFixture('empty').invoke(['init', '--source', 'relative-path', '--yes'])
+
+    logs.should.contain('You need to provide an absolute path for the --source flag.')
+    expect(exitCode).toBe(1)
+  })
 })

--- a/integration/__tests__/commands/init.ts
+++ b/integration/__tests__/commands/init.ts
@@ -1,3 +1,4 @@
+import { createTempDir } from '../../helpers/files'
 import { SeccoCLI } from '../../helpers/invoke-cli'
 
 const initQuestion = 'What is the absolute path to your source?'
@@ -17,5 +18,14 @@ describe('init', () => {
     logs.should.contain(initQuestion)
     logs.should.contain(warning)
     expect(exitCode).toBe(0)
+  })
+  it('should create config file after providing valid input', async () => {
+    const [testDir, cleanup] = await createTempDir('init-command')
+    const input = '/some/absolute/path/to/source'
+    const [_, logs] = SeccoCLI().setCwd(testDir).invoke(['init', '--source', input, '--yes'])
+
+    logs.should.contain('Successfully created .seccorc')
+
+    await cleanup()
   })
 })

--- a/integration/__tests__/commands/packages.ts
+++ b/integration/__tests__/commands/packages.ts
@@ -1,0 +1,2 @@
+describe.todo('packages', () => {
+})

--- a/integration/__tests__/error-scenarios/missing-information.ts
+++ b/integration/__tests__/error-scenarios/missing-information.ts
@@ -1,7 +1,7 @@
 import { join } from 'pathe'
-import { SeccoCLI } from '../helpers/invoke-cli'
+import { SeccoCLI } from '../../helpers/invoke-cli'
 
-const missingSourcePackagesLocation = join(__dirname, '..', 'fixtures', 'missing-source-packages')
+const missingSourcePackagesLocation = join(__dirname, '..', '..', 'fixtures', 'missing-source-packages')
 
 describe('missing information', () => {
   it('should display error when no .seccorc or env var is found', () => {

--- a/integration/__tests__/features/pnpm-workspaces.ts
+++ b/integration/__tests__/features/pnpm-workspaces.ts
@@ -24,8 +24,6 @@ describe.runIf(isPnpm)('pnpm workspaces', () => {
   it('should support protocol and catalogs', () => {
     const [exitCode, logs] = app.cli(['--scan-once', '--force-verdaccio', '--verbose', 'packages', 'say-hello-world'])
 
-    logs.logOutput()
-
     logs.should.contain('[log] [Verdaccio] Starting server...')
     logs.should.contain('[log] [Verdaccio] Started successfully!')
     logs.should.contain('[log] Publishing `say-hello-world@0.0.2-secco-')

--- a/integration/__tests__/features/pnpm-workspaces.ts
+++ b/integration/__tests__/features/pnpm-workspaces.ts
@@ -1,7 +1,7 @@
-import type { Application } from '../models/application'
+import type { Application } from '../../models/application'
 import getPort from 'get-port'
-import { renameFixture } from '../helpers/renamer'
-import { presets } from '../presets'
+import { renameFixture } from '../../helpers/renamer'
+import { presets } from '../../presets'
 
 const isPnpm = process.env.INTEGRATION_PM_NAME === 'pnpm'
 
@@ -23,6 +23,8 @@ describe.runIf(isPnpm)('pnpm workspaces', () => {
 
   it('should support protocol and catalogs', () => {
     const [exitCode, logs] = app.cli(['--scan-once', '--force-verdaccio', '--verbose', 'packages', 'say-hello-world'])
+
+    logs.logOutput()
 
     logs.should.contain('[log] [Verdaccio] Starting server...')
     logs.should.contain('[log] [Verdaccio] Started successfully!')

--- a/integration/__tests__/features/scan-once.ts
+++ b/integration/__tests__/features/scan-once.ts
@@ -1,7 +1,7 @@
-import type { Application } from '../models/application'
+import type { Application } from '../../models/application'
 import getPort from 'get-port'
-import { renameFixture } from '../helpers/renamer'
-import { presets } from '../presets'
+import { renameFixture } from '../../helpers/renamer'
+import { presets } from '../../presets'
 
 describe.sequential('scan-once', () => {
   describe.sequential('single package', () => {

--- a/integration/helpers/files.ts
+++ b/integration/helpers/files.ts
@@ -1,0 +1,50 @@
+import { access, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'pathe'
+
+/**
+ * Remove a directory and all its contents.
+ */
+export async function removeDir(absolutePath: string) {
+  await rm(absolutePath, { recursive: true, force: true })
+}
+
+/**
+ * Create an isolated temporary directory for testing.
+ *
+ * @returns - A tuple with the absolute path to the temporary directory and a cleanup function to remove it.
+ */
+export async function createTempDir(name: string) {
+  const tempDir = process.env.RUNNER_TEMP || tmpdir()
+  const isolatedDir = await mkdtemp(join(tempDir, `secco-${name}-`))
+
+  return [isolatedDir, async () => {
+    await removeDir(isolatedDir)
+  }] as const
+}
+
+/**
+ * Validate that at the given absolute path a file exists.
+ */
+export async function fileExists(absolutePath: string) {
+  try {
+    await access(absolutePath)
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+/**
+ * Check if a file contains the given text.
+ */
+export async function fileContainsText(absolutePath: string, text: string) {
+  try {
+    const fileContent = await readFile(absolutePath, 'utf-8')
+    return fileContent.includes(text)
+  }
+  catch {
+    return false
+  }
+}

--- a/integration/helpers/invoke-cli.ts
+++ b/integration/helpers/invoke-cli.ts
@@ -15,6 +15,7 @@ export function SeccoCLI() {
   let env: Record<string, string> = {}
   let cwd = ''
   let cliLocation = builtCliLocation
+  let input = ''
 
   const self = {
     setEnv: (_env: Record<string, string>) => {
@@ -33,6 +34,10 @@ export function SeccoCLI() {
       cliLocation = _cliLocation
       return self
     },
+    setInput: (_input: string) => {
+      input = _input
+      return self
+    },
     invoke: (args: Array<string>): InvokeResult => {
       const NODE_ENV = 'production'
 
@@ -43,6 +48,7 @@ export function SeccoCLI() {
           {
             cwd,
             env: { NODE_ENV, ...env },
+            input,
           },
         )
 

--- a/integration/helpers/invoke-cli.ts
+++ b/integration/helpers/invoke-cli.ts
@@ -12,13 +12,13 @@ type CreateLogsMatcherReturn = ReturnType<typeof createLogsMatcher>
 export type InvokeResult = [exitCode: number | undefined, logsMatcher: CreateLogsMatcherReturn]
 
 export function SeccoCLI() {
-  let env: Record<string, string> = {}
+  let env: Record<string, string | undefined> = {}
   let cwd = ''
   let cliLocation = builtCliLocation
   let input = ''
 
   const self = {
-    setEnv: (_env: Record<string, string>) => {
+    setEnv: (_env: Record<string, string | undefined>) => {
       env = _env
       return self
     },
@@ -47,7 +47,10 @@ export function SeccoCLI() {
           [cliLocation].concat(args),
           {
             cwd,
-            env: { NODE_ENV, ...env },
+            env: {
+              NODE_ENV,
+              ...env,
+            },
             input,
           },
         )

--- a/integration/vitest.config.ts
+++ b/integration/vitest.config.ts
@@ -4,9 +4,9 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     name: 'Integration tests',
-    include: ['integration/__tests__/*.ts'],
+    include: ['integration/__tests__/**/*.ts'],
     globals: true,
     reporters: [process.env.CI ? 'default' : 'verbose'],
-    testTimeout: 2147483647,
+    testTimeout: 60_000, // 60 seconds
   },
 })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,11 +20,13 @@ const parser = yargsInstace
   .usage('Usage: $0 <command>')
   .command(commands)
   .option('scan-once', {
+    alias: 's',
     type: 'boolean',
     default: false,
     description: 'Scan source once and do not start file watching',
   })
   .option('force-verdaccio', {
+    alias: 'f',
     type: 'boolean',
     default: false,
     description: 'Disable file copying/watching and force usage of Verdaccio',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,32 +1,53 @@
 #!/usr/bin/env node
 
 import type { ArgumentsCamelCase } from 'yargs'
-import type { CliArguments, Destination, Source } from './types'
+import type { CliArguments } from './types'
 import process from 'node:process'
-import { detectPackageManager } from 'nypm'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
-import { commands } from './commands'
-import { CLI_NAME } from './constants'
-import { getConfig } from './utils/config'
-import { checkDirHasPackageJson, findWorkspacesInDestination, findWorkspacesInSource, getAbsolutePathsForDestinationPackages, getDestinationPackages, getPackageNamesToFilePath, getPackages } from './utils/initial-setup'
-import { isTruthy } from './utils/is-truthy'
-import { logger } from './utils/logger'
-import { watcher } from './watcher'
+import { initialize } from './commands/init'
+import { CONFIG_FILE_NAME } from './constants'
+import { main } from './main'
 
 const input = hideBin(process.argv)
 const yargsInstace = yargs(input)
 
 yargsInstace
   .usage('Usage: $0 <command>')
-  .command(commands)
   .command(
     '$0',
     'Scan destination and copy files from source',
     () => {},
     async (argv: ArgumentsCamelCase<CliArguments>) => {
-      await run(argv)
+      await main(argv)
     },
+  )
+  .command(
+    'packages [packageNames...]',
+    'Specify list of packages you want to link',
+    y => y.positional('packageNames', {
+      describe: 'Names of packages to link',
+      type: 'string',
+      array: true,
+    }),
+    async (argv: ArgumentsCamelCase<CliArguments>) => {
+      await main(argv)
+    },
+  )
+  .command(
+    'init',
+    `Initialize a new ${CONFIG_FILE_NAME} file`,
+    y => y.options({
+      source: {
+        type: 'string',
+        description: 'Absolute path to the source directory',
+      },
+      yes: {
+        type: 'boolean',
+        description: 'Skip confirmation prompts',
+      },
+    }),
+    initialize,
   )
   .option('scan-once', {
     alias: 's',
@@ -56,77 +77,3 @@ yargsInstace
   .showHelpOnFail(false)
   .detectLocale(false)
   .parseAsync()
-
-async function run(argv: ArgumentsCamelCase<CliArguments>) {
-  const verbose = argv.verbose || isTruthy(process.env.VERBOSE)
-
-  if (verbose)
-    logger.level = 4
-
-  const seccoConfig = getConfig()
-  logger.debug(`Successfully loaded configuration:
-
-${JSON.stringify(seccoConfig, null, 2)}`)
-
-  checkDirHasPackageJson()
-
-  const destinationPath = process.cwd()
-
-  const { source: sourceConfig } = seccoConfig
-  const { hasWorkspaces: sourceHasWorkspaces, workspaces: sourceWorkspaces } = findWorkspacesInSource(sourceConfig.path)
-  const { hasWorkspaces: destinationHasWorkspaces, workspaces: destinationWorkspaces } = findWorkspacesInDestination(destinationPath)
-
-  const pmSource = await detectPackageManager(sourceConfig.path, { includeParentDirs: false })
-  const pmDestination = await detectPackageManager(destinationPath, { includeParentDirs: false })
-
-  if (!pmDestination) {
-    logger.fatal(`Failed to detect package manager in ${destinationPath}
-
-If you have control over the destination, manually add the "packageManager" key to its \`package.json\` file.`)
-    process.exit(1)
-  }
-
-  logger.debug(`Detected package manager in source: ${pmSource?.name}`)
-  logger.debug(`Detected package manager in destination: ${pmDestination?.name}`)
-  logger.debug(`Source has workspaces: ${sourceHasWorkspaces}`)
-  logger.debug(`Destination has workspaces: ${destinationHasWorkspaces}`)
-
-  const sourcePackages = getPackages(sourceConfig.path, sourceWorkspaces)
-  logger.debug(`Found ${sourcePackages.length} ${sourcePackages.length === 1 ? 'package' : 'packages'} in source.`)
-  const packageNamesToFilePath = getPackageNamesToFilePath()
-  const destinationPackages = getDestinationPackages(sourcePackages, destinationWorkspaces)
-  const absolutePathsForDestinationPackages = getAbsolutePathsForDestinationPackages()
-  logger.debug(`Found ${destinationPackages.length} ${destinationPackages.length === 1 ? 'package' : 'packages'} in destination.`)
-
-  if (!argv?.packageNames && destinationPackages.length === 0) {
-    logger.error(`You haven't got any source dependencies in your current \`package.json\`.
-You probably want to use the packages command to start developing. Example:
-
-${CLI_NAME} packages package-a package-b
-
-If you only want to use \`${CLI_NAME}\` you'll need to add the dependencies to your \`package.json\`.`)
-
-    if (!argv.forceVerdaccio)
-      process.exit(1)
-
-    else
-      logger.info('Continuing other dependency installation due to \`--force-verdaccio\` flag')
-  }
-
-  const source: Source = {
-    ...sourceConfig,
-    hasWorkspaces: sourceHasWorkspaces,
-    packages: sourcePackages,
-    packageNamesToFilePath,
-    pm: pmSource,
-  }
-
-  const destination: Destination = {
-    packages: destinationPackages,
-    hasWorkspaces: destinationHasWorkspaces,
-    absolutePathsForDestinationPackages,
-    pm: pmDestination,
-  }
-
-  watcher(source, destination, argv.packageNames, { scanOnce: argv.scanOnce, forceVerdaccio: argv.forceVerdaccio, verbose })
-}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import type { ArgumentsCamelCase } from 'yargs'
 import type { CliArguments, Destination, Source } from './types'
 import process from 'node:process'
 import { detectPackageManager } from 'nypm'
@@ -16,9 +17,17 @@ import { watcher } from './watcher'
 const input = hideBin(process.argv)
 const yargsInstace = yargs(input)
 
-const parser = yargsInstace
+yargsInstace
   .usage('Usage: $0 <command>')
   .command(commands)
+  .command(
+    '$0',
+    'Scan destination and copy files from source',
+    () => {},
+    async (argv: ArgumentsCamelCase<CliArguments>) => {
+      await run(argv)
+    },
+  )
   .option('scan-once', {
     alias: 's',
     type: 'boolean',
@@ -41,14 +50,14 @@ const parser = yargsInstace
   .example([
     ['$0', 'Scan destination and copy files from source'],
     ['$0 packages ars aurea', 'Copy specified packages from source to destination'],
+    ['$0 init --source=/absolute/path --yes', 'Create a .seccorc file in the current dir with the provided source path without any prompts'],
   ])
   .wrap(yargsInstace.terminalWidth())
   .showHelpOnFail(false)
   .detectLocale(false)
   .parseAsync()
 
-async function run() {
-  const argv: CliArguments = await parser
+async function run(argv: ArgumentsCamelCase<CliArguments>) {
   const verbose = argv.verbose || isTruthy(process.env.VERBOSE)
 
   if (verbose)
@@ -121,5 +130,3 @@ If you only want to use \`${CLI_NAME}\` you'll need to add the dependencies to y
 
   watcher(source, destination, argv.packageNames, { scanOnce: argv.scanOnce, forceVerdaccio: argv.forceVerdaccio, verbose })
 }
-
-run()

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,4 +1,0 @@
-import * as init from './init'
-import * as packages from './packages'
-
-export const commands = [init, packages]

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -61,7 +61,7 @@ async function initialize(argv: ArgumentsCamelCase<InitArgs>) {
   if (argv?.yes) {
     setConfig(configValues)
     logger.success(`Successfully created ${CONFIG_FILE_NAME}`)
-    process.exit(0)
+    return
   }
 
   const optionsToDisplay = serialize(configValues)
@@ -82,13 +82,12 @@ ${optionsToDisplay}
 
   if (!confirm) {
     logger.info('Ok, bye!')
-    process.exit(0)
+    return
   }
 
   setConfig(configValues)
 
   logger.success(`Successfully created ${CONFIG_FILE_NAME}`)
-  process.exit(0)
 }
 
 export const command = 'init'

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,3 +1,4 @@
+import type { ArgumentsCamelCase, Argv } from 'yargs'
 import type { Source } from '../types'
 import type { Config } from '../utils/config'
 import { isAbsolute } from 'node:path'
@@ -12,32 +13,55 @@ import { logger } from '../utils/logger'
 
 type RequiredSourceConfig = Pick<Source, 'path'>
 
+interface InitArgs {
+  source?: string
+  yes?: boolean
+}
+
 /**
  * When running `secco init` we want to ask the user a few questions to create a new config file.
  * Warns if the file already exists.
  */
-async function initialize() {
+async function initialize(argv: ArgumentsCamelCase<InitArgs>) {
   if (hasConfigFile())
     logger.warn(`${CONFIG_FILE_NAME} file already exists in this directory. If you continue this wizard the file will be overwritten.`)
 
-  const requiredQuestions = await new Enquirer<RequiredSourceConfig>().prompt([
-    {
-      type: 'input',
-      name: 'path',
-      message: 'What is the absolute path to your source?',
-      validate: (input) => {
-        if (!isAbsolute(input))
-          return 'You need to use an absolute path'
+  let sourcePath: string
 
-        return true
+  if (argv?.source) {
+    if (!isAbsolute(argv.source)) {
+      logger.fatal('You need to provide an absolute path for the --source flag.')
+      process.exit(1)
+    }
+    sourcePath = argv.source
+  }
+  else {
+    const requiredQuestions = await new Enquirer<RequiredSourceConfig>().prompt([
+      {
+        type: 'input',
+        name: 'path',
+        message: 'What is the absolute path to your source?',
+        validate: (input) => {
+          if (!isAbsolute(input))
+            return 'You need to use an absolute path'
+
+          return true
+        },
       },
-    },
-  ])
+    ])
+    sourcePath = requiredQuestions.path
+  }
 
   const configValues: Config = {
     source: {
-      path: requiredQuestions.path,
+      path: sourcePath,
     },
+  }
+
+  if (argv?.yes) {
+    setConfig(configValues)
+    logger.success(`Successfully created ${CONFIG_FILE_NAME}`)
+    process.exit(0)
   }
 
   const optionsToDisplay = serialize(configValues)
@@ -69,5 +93,16 @@ ${optionsToDisplay}
 
 export const command = 'init'
 export const desc = `Initialize a new ${CONFIG_FILE_NAME} file`
-export const builder = {}
+export function builder(yargs: Argv): Argv<InitArgs> {
+  return yargs.options({
+    source: {
+      type: 'string',
+      description: 'Absolute path to the source directory',
+    },
+    yes: {
+      type: 'boolean',
+      description: 'Skip confirmation prompts',
+    },
+  })
+}
 export const handler = initialize

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,4 @@
-import type { ArgumentsCamelCase, Argv } from 'yargs'
+import type { ArgumentsCamelCase } from 'yargs'
 import type { Source } from '../types'
 import type { Config } from '../utils/config'
 import { isAbsolute } from 'node:path'
@@ -22,7 +22,7 @@ interface InitArgs {
  * When running `secco init` we want to ask the user a few questions to create a new config file.
  * Warns if the file already exists.
  */
-async function initialize(argv: ArgumentsCamelCase<InitArgs>) {
+export async function initialize(argv: ArgumentsCamelCase<InitArgs>) {
   if (hasConfigFile())
     logger.warn(`${CONFIG_FILE_NAME} file already exists in this directory. If you continue this wizard the file will be overwritten.`)
 
@@ -42,6 +42,10 @@ async function initialize(argv: ArgumentsCamelCase<InitArgs>) {
         name: 'path',
         message: 'What is the absolute path to your source?',
         validate: (input) => {
+          if (input === '') {
+            return false
+          }
+
           if (!isAbsolute(input))
             return 'You need to use an absolute path'
 
@@ -89,19 +93,3 @@ ${optionsToDisplay}
 
   logger.success(`Successfully created ${CONFIG_FILE_NAME}`)
 }
-
-export const command = 'init'
-export const desc = `Initialize a new ${CONFIG_FILE_NAME} file`
-export function builder(yargs: Argv): Argv<InitArgs> {
-  return yargs.options({
-    source: {
-      type: 'string',
-      description: 'Absolute path to the source directory',
-    },
-    yes: {
-      type: 'boolean',
-      description: 'Skip confirmation prompts',
-    },
-  })
-}
-export const handler = initialize

--- a/src/commands/packages.ts
+++ b/src/commands/packages.ts
@@ -1,8 +1,0 @@
-export const command = 'packages [packageNames...]'
-export const desc = 'Specify list of packages you want to link'
-export const builder = {
-  packageNames: {
-    array: true,
-  },
-}
-export function handler() {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,84 @@
+import type { ArgumentsCamelCase } from 'yargs'
+import type { CliArguments, Destination, Source } from './types'
+import process from 'node:process'
+import { detectPackageManager } from 'nypm'
+import { CLI_NAME } from './constants'
+import { getConfig } from './utils/config'
+import { checkDirHasPackageJson, findWorkspacesInDestination, findWorkspacesInSource, getAbsolutePathsForDestinationPackages, getDestinationPackages, getPackageNamesToFilePath, getPackages } from './utils/initial-setup'
+import { isTruthy } from './utils/is-truthy'
+import { logger } from './utils/logger'
+import { watcher } from './watcher'
+
+export async function main(argv: ArgumentsCamelCase<CliArguments>) {
+  const verbose = argv.verbose || isTruthy(process.env.VERBOSE)
+
+  if (verbose)
+    logger.level = 4
+
+  const seccoConfig = getConfig()
+  logger.debug(`Successfully loaded configuration:
+
+${JSON.stringify(seccoConfig, null, 2)}`)
+
+  checkDirHasPackageJson()
+
+  const destinationPath = process.cwd()
+
+  const { source: sourceConfig } = seccoConfig
+  const { hasWorkspaces: sourceHasWorkspaces, workspaces: sourceWorkspaces } = findWorkspacesInSource(sourceConfig.path)
+  const { hasWorkspaces: destinationHasWorkspaces, workspaces: destinationWorkspaces } = findWorkspacesInDestination(destinationPath)
+
+  const pmSource = await detectPackageManager(sourceConfig.path, { includeParentDirs: false })
+  const pmDestination = await detectPackageManager(destinationPath, { includeParentDirs: false })
+
+  if (!pmDestination) {
+    logger.fatal(`Failed to detect package manager in ${destinationPath}
+
+If you have control over the destination, manually add the "packageManager" key to its \`package.json\` file.`)
+    process.exit(1)
+  }
+
+  logger.debug(`Detected package manager in source: ${pmSource?.name}`)
+  logger.debug(`Detected package manager in destination: ${pmDestination?.name}`)
+  logger.debug(`Source has workspaces: ${sourceHasWorkspaces}`)
+  logger.debug(`Destination has workspaces: ${destinationHasWorkspaces}`)
+
+  const sourcePackages = getPackages(sourceConfig.path, sourceWorkspaces)
+  logger.debug(`Found ${sourcePackages.length} ${sourcePackages.length === 1 ? 'package' : 'packages'} in source.`)
+  const packageNamesToFilePath = getPackageNamesToFilePath()
+  const destinationPackages = getDestinationPackages(sourcePackages, destinationWorkspaces)
+  const absolutePathsForDestinationPackages = getAbsolutePathsForDestinationPackages()
+  logger.debug(`Found ${destinationPackages.length} ${destinationPackages.length === 1 ? 'package' : 'packages'} in destination.`)
+
+  if (!argv?.packageNames && destinationPackages.length === 0) {
+    logger.error(`You haven't got any source dependencies in your current \`package.json\`.
+You probably want to use the packages command to start developing. Example:
+
+${CLI_NAME} packages package-a package-b
+
+If you only want to use \`${CLI_NAME}\` you'll need to add the dependencies to your \`package.json\`.`)
+
+    if (!argv.forceVerdaccio)
+      process.exit(1)
+
+    else
+      logger.info('Continuing other dependency installation due to \`--force-verdaccio\` flag')
+  }
+
+  const source: Source = {
+    ...sourceConfig,
+    hasWorkspaces: sourceHasWorkspaces,
+    packages: sourcePackages,
+    packageNamesToFilePath,
+    pm: pmSource,
+  }
+
+  const destination: Destination = {
+    packages: destinationPackages,
+    hasWorkspaces: destinationHasWorkspaces,
+    absolutePathsForDestinationPackages,
+    pm: pmDestination,
+  }
+
+  watcher(source, destination, argv.packageNames, { scanOnce: argv.scanOnce, forceVerdaccio: argv.forceVerdaccio, verbose })
+}

--- a/src/verdaccio/cleanup-tasks.ts
+++ b/src/verdaccio/cleanup-tasks.ts
@@ -3,6 +3,7 @@ import { onExit } from 'signal-exit'
 import { logger } from '../utils/logger'
 
 const cleanupTasks: Set<Function> = new Set()
+let isGracefulExit = false
 
 export function registerCleanupTask<F extends Function>(taskFn: F) {
   cleanupTasks.add(taskFn)
@@ -14,8 +15,14 @@ export function registerCleanupTask<F extends Function>(taskFn: F) {
   }
 }
 
+export function prepareGracefulExit() {
+  isGracefulExit = true
+  cleanupTasks.forEach(taskFn => taskFn())
+  cleanupTasks.clear()
+}
+
 onExit((code) => {
-  if (cleanupTasks.size > 0) {
+  if (cleanupTasks.size > 0 && !isGracefulExit) {
     logger.warn(`Process exited with code ${code} in the middle of publishing. Cleaning up...`)
     cleanupTasks.forEach(taskFn => taskFn())
   }

--- a/src/verdaccio/cleanup-tasks.ts
+++ b/src/verdaccio/cleanup-tasks.ts
@@ -23,7 +23,7 @@ export function prepareGracefulExit() {
 
 onExit((code) => {
   if (cleanupTasks.size > 0 && !isGracefulExit) {
-    logger.warn(`Process exited with code ${code} in the middle of publishing. Cleaning up...`)
+    logger.warn(`Process exited with code ${code}. Cleaning up...`)
     cleanupTasks.forEach(taskFn => taskFn())
   }
 })

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -14,11 +14,14 @@ import { logger } from './utils/logger'
 import { setDefaultSpawnStdio } from './utils/promisified-spawn'
 import { traversePkgDeps } from './utils/traverse-pkg-deps'
 import { publishPackagesAndInstall } from './verdaccio'
+import { prepareGracefulExit } from './verdaccio/cleanup-tasks'
 
 let numOfCopiedFiles = 0
 const MAX_COPY_RETRIES = 3
 
 function quit() {
+  prepareGracefulExit()
+
   logger.info(`Copied ${numOfCopiedFiles} files. Exiting...`)
   process.exit(0)
 }

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -237,8 +237,14 @@ export async function watcher(source: Source, destination: Destination, packages
         // Skip package.json check since we need it
         if (relativePackageFile !== 'package.json') {
           const isIncluded = filesPatterns.some((pattern) => {
-            // Handle exact matches and directory patterns
-            if (relativePackageFile.startsWith(`${pattern}/`) || relativePackageFile === pattern) {
+            // Handle exact matches
+            if (relativePackageFile === pattern) {
+              return true
+            }
+
+            const normalizedPattern = pattern.endsWith('/') ? pattern.slice(0, -1) : pattern
+
+            if (relativePackageFile.startsWith(`${normalizedPattern}/`)) {
               return true
             }
 


### PR DESCRIPTION
## Description

Bugfixes:
- When `dist/` was in the `files` array of `package.json` it didn't correctly copy over files inside the `dist` directory
- When `--scan-once` and `--force-verdaccio` were used together a warning was thrown about an ungraceful exit. For this codepath any cleanup tasks are run before exiting now. The warning won't show.
- The `init` command ran the whole main function while it should only run the Enquirer prompt. This is fixed now.

Features:
- Add `-s` alias for `--scan-once` and `-f` for `--force-verdaccio`
- Add `--source` and `--yes` flag for `secco init`, making it possible to run the init command in non-interactive mode

Tests:
- Reorganize integration tests
- Add `init` test to check non-interactive creation of file

## Checklist

- [x] `pnpm run test` runs as expected.
- [x] `pnpm run build` runs as expected.
- [ ] (If applicable) Documentation has been updated
